### PR TITLE
Fix the rendering of table headers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,4 +23,4 @@ jobs:
       run: bundle exec rubocop .
 
     - name: Run tests
-      run: bundle exec rake
+      run: bundle exec rspec

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -26,12 +26,20 @@ module GovukMarkdown
       HTML
     end
 
-    def table_cell(content, _alignment)
-      <<~HTML
-        <td class='govuk-table__cell'>
-          #{content}
-        </td>
-      HTML
+    def table_cell(content, _alignment, header)
+      if header
+        <<~HTML
+          <th class='govuk-table__header'>
+            #{content}
+          </th>
+        HTML
+      else
+        <<~HTML
+          <td class='govuk-table__cell'>
+            #{content}
+          </td>
+        HTML
+      end
     end
 
     def header(text, header_level)

--- a/spec/govuk_markdown_spec.rb
+++ b/spec/govuk_markdown_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe GovukMarkdown do
       <table class='govuk-table'>
         <thead class='govuk-table__head'>
           <tr class='govuk-table__row'>
-            <td class='govuk-table__cell'>First name</td>
-            <td class='govuk-table__cell'>Last name</td>
-            <td class='govuk-table__cell'>DOB</td>
+            <th class='govuk-table__header'>First name</th>
+            <th class='govuk-table__header'>Last name</th>
+            <th class='govuk-table__header'>DOB</th>
           </tr>
         </thead>
         <tbody class='govuk-table__body'>


### PR DESCRIPTION
Redcarpet now provides a `header` param which allows us to render either a `<td>` or `<th>` cell accordingly.