### PR TITLE
Add front matter stripping option to renderer

### DIFF
--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -7,7 +7,7 @@ require_relative "./govuk_markdown/renderer"
 
 module GovukMarkdown
   def self.render(markdown, govuk_options = {})
-    renderer = GovukMarkdown::Renderer.new(govuk_options, { with_toc_data: true, link_attributes: { class: "govuk-link" } })
+    renderer = GovukMarkdown::Renderer.new(govuk_options, { with_toc_data: true, strip_front_matter: true, link_attributes: { class: "govuk-link" } })
     Redcarpet::Markdown.new(renderer, tables: true, no_intra_emphasis: true).render(markdown).strip
   end
 end

--- a/lib/govuk_markdown/preprocessor.rb
+++ b/lib/govuk_markdown/preprocessor.rb
@@ -37,6 +37,14 @@ module GovukMarkdown
       self
     end
 
+    def strip_front_matter(enabled)
+      return self unless enabled
+
+      @output = output.gsub(%r{^---\n.*\n---}m, "")
+
+      self
+    end
+
   private
 
     # parse as markdown if there are multiple lines of content

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -2,6 +2,8 @@ module GovukMarkdown
   class Renderer < ::Redcarpet::Render::HTML
     def initialize(govuk_options, options = {})
       @headings_start_with = govuk_options[:headings_start_with]
+      @strip_front_matter = govuk_options[:strip_front_matter]
+
       super options
     end
 
@@ -93,6 +95,7 @@ module GovukMarkdown
         .new(document)
         .inject_inset_text
         .inject_details
+        .strip_front_matter(@strip_front_matter)
         .output
     end
   end

--- a/spec/preprocessor_spec.rb
+++ b/spec/preprocessor_spec.rb
@@ -320,6 +320,63 @@ RSpec.describe "GovukMarkdown with textual component extensions" do
     end
   end
 
+  describe "strip front matter" do
+    let(:input) do
+      <<~MD
+        ---
+        title: Hi
+        tags: hello, world
+        ---
+
+        Waffle waffle waffle waffle.
+
+        Waffle waffle waffle waffle.
+      MD
+    end
+
+    let(:actual_output) { render(input, { strip_front_matter: }) }
+
+    context "when front matter is stripped" do
+      let(:strip_front_matter) { true }
+
+      let(:expected_output) do
+        <<~EXPECTED.strip
+          <p class="govuk-body-m">Waffle waffle waffle waffle.</p>
+          <p class="govuk-body-m">Waffle waffle waffle waffle.</p>
+        EXPECTED
+      end
+
+      it "renders no front matter" do
+        expect(actual_output).not_to include("title")
+      end
+
+      it "renders without front matter" do
+        expect(actual_output).to eql(expected_output)
+      end
+    end
+
+    context "when front matter is not stripped" do
+      let(:strip_front_matter) { false }
+
+      let(:expected_output) do
+        <<~EXPECTED.strip
+          <p class="govuk-body-m">Waffle waffle waffle waffle.</p>
+          <p class="govuk-body-m">Waffle waffle waffle waffle.</p>
+        EXPECTED
+      end
+
+      it "renders the front matter" do
+        expect(actual_output).to include(%(<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">))
+        expect(actual_output).to include(%(<p class="govuk-body-m">title: Hi</p>))
+        expect(actual_output).to include(%(<h2 id="tags-hello-world" class="govuk-heading-l">tags: hello, world</h2>))
+      end
+
+      it "renders the content too" do
+        expect(actual_output).to include(expected_output)
+      end
+    end
+  end
+
   describe "multiple preprocessing steps" do
     let(:expected_output) do
       <<~HTML

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require_relative "./../lib/govuk_markdown"
 require "pry"
 
-def render(content)
-  GovukMarkdown.render(content)
+def render(content, govuk_options = {})
+  GovukMarkdown.render(content, govuk_options)
 end
 
 def expect_equal_ignoring_ws(first, second)


### PR DESCRIPTION
Sometimes front matter is included in files but we don't want it to be part of the final document. Markdown fences are intepreted as horizontal rules and the keys and values within are rendered in paragraphs, which looks ugly.

The new strip_front_matter argument, which defaults to true, removes three dashes at the beginning of the document up to a matching three dash closing fence.
