### PR TITLE
Enable smartypants by default

### DIFF
--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -1,5 +1,7 @@
 module GovukMarkdown
   class Renderer < ::Redcarpet::Render::HTML
+    include Redcarpet::Render::SmartyPants
+
     def initialize(govuk_options, options = {})
       @headings_start_with = govuk_options[:headings_start_with]
       @strip_front_matter = govuk_options[:strip_front_matter]

--- a/spec/preprocessor_spec.rb
+++ b/spec/preprocessor_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe "GovukMarkdown with textual component extensions" do
               </span>
             </summary>
             <div class="govuk-details__text">
-              Don't you just love more details.
+              Don&rsquo;t you just love more details.
             </div>
           </details>
 


### PR DESCRIPTION
Most people type straight apostrophes because [they're actually on peoples' keyboards](https://smartquotesforsmartpeople.com/). We ought to be [displaying fancy/curly ones where possible](https://design.tax.service.gov.uk/hmrc-content-style-guide/).

This change enables [RedCarpet's SmartyPants implementation](https://github.com/vmg/redcarpet?tab=readme-ov-file#also-now-our-pants-are-much-smarter) so we'll benefit from it everywhere we render blocks of markdown.
