### PR TITLE
Create a mixin module from renderer class

### DIFF
--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -4,6 +4,7 @@ require "redcarpet"
 require_relative "./govuk_markdown/version"
 require_relative "./govuk_markdown/preprocessor"
 require_relative "./govuk_markdown/renderer"
+require_relative "./govuk_markdown/renderer/mixin"
 
 module GovukMarkdown
   def self.render(markdown, govuk_options = {})

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -1,104 +1,15 @@
 module GovukMarkdown
   class Renderer < ::Redcarpet::Render::HTML
-    include Redcarpet::Render::SmartyPants
+    autoload :Mixin, "govuk_markdown/renderer/mixin"
+
+    include ::Redcarpet::Render::SmartyPants
+    include Mixin
 
     def initialize(govuk_options, options = {})
       @headings_start_with = govuk_options[:headings_start_with]
       @strip_front_matter = govuk_options[:strip_front_matter]
 
       super options
-    end
-
-    def table(header, body)
-      <<~HTML
-        <table class='govuk-table'>
-          <thead class='govuk-table__head'>
-            #{header}
-          </thead>
-          <tbody class='govuk-table__body'>
-            #{body}
-          </tbody>
-        </table>
-      HTML
-    end
-
-    def table_row(content)
-      <<~HTML
-        <tr class='govuk-table__row'>
-          #{content}
-        </tr>
-      HTML
-    end
-
-    def table_cell(content, _alignment, header)
-      if header
-        <<~HTML
-          <th class='govuk-table__header'>
-            #{content}
-          </th>
-        HTML
-      else
-        <<~HTML
-          <td class='govuk-table__cell'>
-            #{content}
-          </td>
-        HTML
-      end
-    end
-
-    def header(text, header_level)
-      valid_header_sizes = %w[xl l m s].freeze
-
-      start_size = valid_header_sizes.include?(@headings_start_with) ? @headings_start_with : "xl"
-
-      start_size_index = valid_header_sizes.find_index(start_size)
-
-      header_size = valid_header_sizes[start_size_index + header_level - 1] || "s"
-
-      id_attribute = @options[:with_toc_data] ? " id=\"#{text.parameterize}\"" : ""
-      <<~HTML
-        <h#{header_level}#{id_attribute} class="govuk-heading-#{header_size}">#{text}</h#{header_level}>
-      HTML
-    end
-
-    def paragraph(text)
-      <<~HTML
-        <p class="govuk-body-m">#{text}</p>
-      HTML
-    end
-
-    def list(contents, list_type)
-      case list_type
-      when :unordered
-        <<~HTML
-          <ul class="govuk-list govuk-list--bullet">
-            #{contents}
-          </ul>
-        HTML
-      when :ordered
-        <<~HTML
-          <ol class="govuk-list govuk-list--number">
-            #{contents}
-          </ol>
-        HTML
-      else
-        raise "Unexpected type #{list_type.inspect}"
-      end
-    end
-
-    def hrule
-      <<~HTML
-        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      HTML
-    end
-
-    def preprocess(document)
-      Preprocessor
-        .new(document)
-        .inject_inset_text
-        .inject_details
-        .strip_front_matter(@strip_front_matter)
-        .output
     end
   end
 end

--- a/lib/govuk_markdown/renderer/mixin.rb
+++ b/lib/govuk_markdown/renderer/mixin.rb
@@ -1,0 +1,97 @@
+module GovukMarkdown
+  # Renderer::Mixin overrides methods in Redcarpet::Render::HTML.
+  # See `GovukMarkdown::Renderer` for an example of how to include it.
+  module Renderer::Mixin
+    def table(header, body)
+      <<~HTML
+        <table class='govuk-table'>
+          <thead class='govuk-table__head'>
+            #{header}
+          </thead>
+          <tbody class='govuk-table__body'>
+            #{body}
+          </tbody>
+        </table>
+      HTML
+    end
+
+    def table_row(content)
+      <<~HTML
+        <tr class='govuk-table__row'>
+          #{content}
+        </tr>
+      HTML
+    end
+
+    def table_cell(content, _alignment, header)
+      if header
+        <<~HTML
+          <th class='govuk-table__header'>
+            #{content}
+          </th>
+        HTML
+      else
+        <<~HTML
+          <td class='govuk-table__cell'>
+            #{content}
+          </td>
+        HTML
+      end
+    end
+
+    def header(text, header_level)
+      valid_header_sizes = %w[xl l m s].freeze
+
+      start_size = valid_header_sizes.include?(@headings_start_with) ? @headings_start_with : "xl"
+
+      start_size_index = valid_header_sizes.find_index(start_size)
+
+      header_size = valid_header_sizes[start_size_index + header_level - 1] || "s"
+
+      id_attribute = @options[:with_toc_data] ? " id=\"#{text.parameterize}\"" : ""
+      <<~HTML
+        <h#{header_level}#{id_attribute} class="govuk-heading-#{header_size}">#{text}</h#{header_level}>
+      HTML
+    end
+
+    def paragraph(text)
+      <<~HTML
+        <p class="govuk-body-m">#{text}</p>
+      HTML
+    end
+
+    def list(contents, list_type)
+      case list_type
+      when :unordered
+        <<~HTML
+          <ul class="govuk-list govuk-list--bullet">
+            #{contents}
+          </ul>
+        HTML
+      when :ordered
+        <<~HTML
+          <ol class="govuk-list govuk-list--number">
+            #{contents}
+          </ol>
+        HTML
+      else
+        raise "Unexpected type #{list_type.inspect}"
+      end
+    end
+
+    def hrule
+      <<~HTML
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+      HTML
+    end
+
+    def preprocess(document)
+      Preprocessor
+        .new(document)
+        .inject_inset_text
+        .inject_details
+        .strip_front_matter(@strip_front_matter)
+        .output
+    end
+  end
+end


### PR DESCRIPTION
First off, thanks for creating and sharing this awesome gem! On GOV.UK Forms we're using it in a couple of places, it's a big help.

In [forms-product-page], we've been using it with the [markdown-rails] gem, which is nice and lightweight, but it's a little awkward and we had to rewrite a bit more code than we'd like to get it to work, and it's pretty brittle (see https://github.com/alphagov/forms-product-page/pull/940#issuecomment-3674942256).

It would be great if govuk-markdown could be included as a mixin into a class, I think that would make it easier for us to use it with markdown-rails.

I've raised this PR as a moving the existing methods into a module seemed pretty straightfoward, happy to take on whatever feedback or suggestions you have.

Many thanks!

[forms-product-page]: https://github.com/alphagov/forms-product-page
[markdown-rails]: https://github.com/sitepress/markdown-rails